### PR TITLE
Updating dropwizard dependency to 1.0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.class
+target/
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ For example, the kinds of responses you'll get from a REST endpoint in your serv
 }
 ```
 
+### Dropwizard Compatability Matrix
+
+| Dropwizard Version | Peer-Authenticator Version |
+|--------------------|----------------------------|
+|        0.8.*       |            1.x.y           |
+|        0.9.*       |            N/A             |
+|        1.0.*       |            2.x.y           |
+
 ## Integration
 Add this JAR to your Dropwizard -server's POM
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # dropwizard-json-exceptions
 
+## 2.0.0 2016/12/xx
+
+* Upgraded dropwizard dependency to 1.0.5
+
 ## 1.1.2 2016/06/21
 
 * All WebAppExceptions should be mapped to JSON with their own response type

--- a/pom.xml
+++ b/pom.xml
@@ -10,15 +10,15 @@
 
     <groupId>com.washingtonpost.dropwizard</groupId>
     <artifactId>dropwizard-json-exceptions</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
-        <version.dropwizard>0.8.1</version.dropwizard>
+        <version.dropwizard>1.0.5</version.dropwizard>
         <version.jackson.xml.databind>0.6.2</version.jackson.xml.databind>
         <version.junit>4.12</version.junit>
         <version.skyscreamer.jsonassert>1.2.3</version.skyscreamer.jsonassert>
-        <version.slf4j>1.7.12</version.slf4j>
+        <version.slf4j>1.7.21</version.slf4j>
         <version.wp.checkstyle>2.0</version.wp.checkstyle>
     </properties>
 


### PR DESCRIPTION
Just bumps up the version of the declared dropwizard dependency to 1.0.5; slf4j updated too

@gengel if you're in the holiday releasing spirit, can you do this one too?  Thanks!